### PR TITLE
Adding folders and READMEs to put CDIF examples in

### DIFF
--- a/Data_Examples/CDIF_Examples/README.md
+++ b/Data_Examples/CDIF_Examples/README.md
@@ -1,0 +1,13 @@
+# About
+This folder is meant to be used to store examples files from each NFDI consortium in either JSON-LD or TTL that are 
+conform to CDIF. The content of these files should be a CDIF conform knowledge graph that contains necessary the 
+domain-independent metadata of a dataset (e.g. author, date, ...) as well as domain-specific metadata (e.g. used 
+observation method/tools, ...)
+
+# File naming conventions
+Please use the following file naming convention:
+
+```
+[ConsortiumAcronym]_CDIF_ex_[integer].[ttl/jsonld] 
+example: NFDI4Chem_CDIF_ex_1.ttl
+```

--- a/Data_Examples/CDIF_Examples/README.md
+++ b/Data_Examples/CDIF_Examples/README.md
@@ -1,8 +1,13 @@
 # About
 This folder is meant to be used to store examples files from each NFDI consortium in either JSON-LD or TTL that are 
-conform to CDIF. The content of these files should be a knowledge graph that contains the necessary
+conform to [CDIF](https://cross-domain-interoperability-framework.github.io/cdifbook/). The content of these files should be a knowledge graph that contains the necessary
 domain-independent metadata of a dataset (e.g. author, date, ...) as well as domain-specific metadata (e.g. used 
-observation method/tools, ...)
+observation method/tools, ...).
+
+In our [14-08-2024 call](https://docs.google.com/document/d/14z6kuAdVaiflWUtjqk3LKt-hqg_DeaRCpLY7TFo1PoU), we 
+discussed the  [Discovery Profile](https://cross-domain-interoperability-framework.github.
+io/cdifbook/metadata/discovery.html) and the [Data Integration Profile](https://cross-domain-interoperability-framework.github.io/cdifbook/data_integration/dataintegrationintro.html) and 
+although the former is a necessary prerequisite, it is the latter we are interested in testing here with examples. 
 
 # File naming conventions
 Please use the following file naming convention:

--- a/Data_Examples/CDIF_Examples/README.md
+++ b/Data_Examples/CDIF_Examples/README.md
@@ -1,6 +1,6 @@
 # About
 This folder is meant to be used to store examples files from each NFDI consortium in either JSON-LD or TTL that are 
-conform to CDIF. The content of these files should be a CDIF conform knowledge graph that contains necessary the 
+conform to CDIF. The content of these files should be a knowledge graph that contains the necessary
 domain-independent metadata of a dataset (e.g. author, date, ...) as well as domain-specific metadata (e.g. used 
 observation method/tools, ...)
 

--- a/Data_Examples/README.md
+++ b/Data_Examples/README.md
@@ -1,0 +1,6 @@
+This folder is meant to be used for examples of datasets from each consortium which are annotated using common 
+terminologies. The goal of such examples is the testing of frameworks such as CDIF or I-ADOPT to have some practical 
+examples on how to implement these in harmonized manner throughout NFDI.
+
+It is still open on how to best structure and provide the content within this folder. With regard to the structure, 
+we will start out with subfolders for each framework (e.g. [CDIF_Examples](../Data_Examples/CDIF_Examples))

--- a/Data_Examples/README.md
+++ b/Data_Examples/README.md
@@ -1,5 +1,6 @@
 This folder is meant to be used for examples of datasets from each consortium which are annotated using common 
-terminologies. The goal of such examples is the testing of frameworks such as CDIF or I-ADOPT to have some practical 
+terminologies. The goal of such examples is the testing of frameworks such as [CDIF](https://cross-domain-interoperability-framework.github.io/cdifbook/) or [I-ADOPT](https://i-adopt.github.io/) to have some 
+practical 
 examples on how to implement these in harmonized manner throughout NFDI.
 
 It is still open on how to best structure and provide the content within this folder. With regard to the structure, 


### PR DESCRIPTION
This PR adds folders and READMEs in which we plan to provide concrete file examples that use one of the assessed frameworks (e.g. CDIF) to annotate a dataset with RDF.